### PR TITLE
Use transients as storage as a fallback.

### DIFF
--- a/time-stack.php
+++ b/time-stack.php
@@ -25,8 +25,10 @@ class HM_Time_Stack {
 
 		if ( function_exists( 'apc_store' ) && apc_store( '__test', '123' ) ) {
 			$data = apc_fetch( '_hm_all_stacks' );
-		} else {
+		} elseif ( wp_using_ext_object_cache() ) {
 			$data = wp_cache_get( '_hm_all_stacks' );
+		} else {
+			$data = get_transient( '_hm_all_stacks' );
 		}
 
 		if ( $clear )
@@ -39,8 +41,10 @@ class HM_Time_Stack {
 
 		if ( function_exists( 'apc_store' ) && apc_store( '__test', '123' ) ) {
 			return apc_store( '_hm_all_stacks', $data, 60 );
-		} else {
+		} elseif ( wp_using_ext_object_cache() ) {
 			return wp_cache_set( '_hm_all_stacks', $data, null, 60 );
+		} else {
+			return set_transient( '_hm_all_stacks', $data, 60 );
 		}
 	}
 


### PR DESCRIPTION
Hi Joe; 

I've been using Time-Stack to do some profiling of a page that isn't HTML - so solutions like debug-bar don't work for me. Time-Stack has worked really well - so thanks :)

However - I wanted to profile the code as run WITH and WITHOUT an object cache as many of the users running the code in question won't be using an object cache. 

The attached PR makes the plugin fallback on transients for storage if neither APC, or an external object cache are available meaning it can be used without APC/Memcache.

This WorksForMe[tm], but I'm not sure if there was a deliberate reason not to use transients and insist on external cache - maybe some issue I haven't hit yet?

Comments / feedback welcome - thanks!
